### PR TITLE
Adding Cloud Docs reference items

### DIFF
--- a/docs/azure-plans.rst
+++ b/docs/azure-plans.rst
@@ -1,0 +1,163 @@
+.. _azure-plans:
+
+========================
+Azure subscription plans
+========================
+
+When signing up for the CrateDB Cloud offer on Microsoft Azure Marketplace, you
+have a choice of three different plans. Each of these plans is preconfigured
+for different use cases, depending on how large your product needs are. By
+presenting these plans in terms of ready configurations of database storage,
+memory, and computation capacity, the user is spared the complexity of finding
+exact required hardware combinations themselves.
+
+At the same time, the plans also offer flexibility, since your use case may
+change. Not only is it possible to switch plans, but within a given plan you
+can scale the required capacity for a cluster up or down. In order to make it
+transparent and yet easy to use, this scaling is measured in terms of database
+throughput units (DTUs).
+
+This reference gives a brief description of each plan and subsequently explains
+the meaning and usage of DTUs for scaling and pricing within each plan. In this
+way, making a suitable and effective choice of plan for CrateDB Cloud's Azure
+offer will become straightforward.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+.. _azure-plans-overview:
+
+The CrateDB Cloud plans on Azure Marketplace
+============================================
+
+Currently, CrateDB Cloud's offer on Azure Marketplace provides three different
+plans: **Development**, **General Purpose Basic** and **General Purpose Pro**.
+
+* The **Development** plan is aimed at users who want to try out what CrateDB
+  Cloud has to offer. It offers modest but robust storage, memory, and
+  computation capacity. Although intended for setting up trial clusters to
+  evaluate the product, it offers full flexibility: the capacity can be scaled
+  along three scale units. Per scale unit, one DTU is added (or subtracted).
+
+.. NOTE::
+    Note that the Development plan is not covered by 24/7 support.
+
+* The **General Purpose Basic** plan suits all but very large use cases.
+  It offers the intermediate range of storage, memory, and computation
+  capacity. This plan also can currently be scaled between three scale units,
+  each adding (or subtracting) one DTU.
+* Finally, the **General Purpose Pro** plan is intended for users with very
+  large capacity needs. This plan offers very significant storage, memory, and
+  computation capacity, offering up to four times the ingestion and query
+  capacity of the General Purpose Basic plan and up to an order of magnitude
+  greater storage. The General Purpose Pro plan can also currently be scaled
+  between three scale units, each adding (or subtracting) one DTU.
+
+
+.. _azure-plans-dtus:
+
+Explaining DTUs for scaling and billing
+=======================================
+
+So what are DTUs and how do they work? As mentioned above, to make finding the
+right combination of hardware capacity more tractable and accessible, CrateDB
+Cloud's offer on Azure uses DTUs. These DTUs have essentially two purposes:
+they allow the user to choose the right combination of plan and scale to find
+the capacity they need, and they provide clarity for the purposes of pricing.
+In order to keep things simple, scaling in each plan is currently set up so
+that one scale unit = one DTU, and billing is set up so that Crate.io bills
+only for DTUs/hour actually used.
+
+.. NOTE::
+    Note, however, that scale units do not necessarily *start* at 1 DTU; for
+    example the **Development** plan starts at 3 DTUs and then scales up to 5
+    DTUs.
+
+Let's break this down further to clarify what each of these statements mean.
+
+As seen above, CrateDB Cloud's Azure offer is divided into three plans. Each
+plan has a starting scale (scale unit 1), which can be scaled up to scale unit
+2 or 3. Because the hardware capacity in each plan is different, a scale unit
+in the **Development** plan is of a different size (in terms of storage,
+memory, and computation) than a scale unit in the **General Purpose Pro** plan.
+But scaling within each plan - so between the minimum capacity for that plan
+and the maximum capacity for that plan - is made easy by the division into
+scale units, each of which corresponds to one DTU.
+
+An overview showing the range in terms of capacity of each plan, within which
+the scaling of that plan operates, can be found on the `Azure offer page`_.
+Here one also finds the price per DTU per hour.
+
+To summarize, the DTU approach to scaling means that although the offered plans
+differ considerably in capacity both between each other and per scale unit
+within each plan, the DTU system allows these different magnitudes to be
+compared easily by the user.
+
+The same principle applies to the pricing. If you scale within a plan, you will
+readily know how much capacity you are getting and also how much you will pay
+per hour. This is because you know the capacity of the plan, the fact that one
+scale unit = one DTU, and the price per DTU/hour for that plan. The pricing in
+DTU/hours used is determined for each scale unit in a plan, so that a given
+number of scale units = a given number of DTUs, which for a given plan produces
+a given price. This provides both flexibility and transparency. The pricing can
+also be estimated through the `pricing calculator`_.
+
+The precise calculations of required hardware capacity, actual usage of that
+hardware, and a corresponding cost are all handled by Crate.io. The user only
+needs to consider a plan, a scale within that plan, and the price in DTU/hour
+that corresponds to it.
+
+
+.. _azure-plans-example:
+
+A practical example
+===================
+
+Say you have a use case where you expect to need approximately 6000 ingests per
+second and want corresponding capacity in storage, without having to worry
+about the precise storage size. Also, you want this to be easy to set up and
+clearly priced and billed.
+
+CrateDB Cloud's Azure offer provides a straightforward approach to such a use
+case. Simply compare the plans on offer. You will quickly identify that the
+desired capacity falls within the **General Purpose Pro** plan, which begins at
+2000 ingests/sec. and scales in 2000 ingests/sec. units. You therefore
+subscribe to this plan and scale it up 2 times, from 2000 to 6000 ingests/sec.
+
+Now you have a ready **General Purpose Pro** plan for your cluster at scale
+unit 3. Since each scale unit is currently simply one DTU, and the **General**
+**Purpose Pro** plan begins at 1 DTU, you will directly know that your total
+cost is 3 DTU/hour of that plan. Of course, as always, only actual usage is
+billed.
+
+It is easy to try out different other estimations and their corresponding plans
+and prices using the `price calculator on the CrateDB Cloud website`_.
+
+
+.. _azure-plans-notes:
+
+Cautionary notes
+================
+
+For clarity and to prevent confusion, we add here a few notes of caution:
+
+* The correspondence between one scaling unit and one DTU is provisional and
+  may change in the future.
+* Remember that not all plans, currently or in the future, necessarily start at
+  1 DTU. The **Development** plan currently starts at 3 DTU of that plan. When
+  referring to the pricing per DTU/hour on the Azure offer, keep this in mind.
+  This means the price for 1 DTU/hour listed on the Azure offer is not
+  necessarily the minimum price for a given plan, even when one does not scale
+  further upwards, since one may start at several DTUs even without scaling
+  further.
+* New plans will be offered in the future with different capacity ranges that
+  may suit your use case. Our price calculator and this Reference will then be
+  updated accordingly. Plan terms and prices are subject to change.
+
+
+.. _Azure offer page: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=PlansAndPrice
+.. _pricing calculator: https://crate.io/products/cratedb-cloud/#cloud-calculator
+.. _price calculator on the CrateDB Cloud website: https://crate.io/products/cratedb-cloud/#cloud-calculator

--- a/docs/azure-plans.rst
+++ b/docs/azure-plans.rst
@@ -14,8 +14,8 @@ exact required hardware combinations themselves.
 At the same time, the plans also offer flexibility, since your use case may
 change. Not only is it possible to switch plans, but within a given plan you
 can scale the required capacity for a cluster up or down. In order to make it
-transparent and yet easy to use, this scaling is measured in terms of database
-throughput units (DTUs).
+transparent and yet easy to use, this scaling is measured in terms of Database
+Transaction Units (DTUs).
 
 This reference gives a brief description of each plan and subsequently explains
 the meaning and usage of DTUs for scaling and pricing within each plan. In this

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,93 @@
+.. _concepts:
+
+========
+Concepts
+========
+
+The purpose of this article is to provide information on the main concepts
+encountered while working with, or reading the Documentation of, CrateDB Cloud.
+By providing a brief explanation of these concepts, we hope to make the
+structure of CrateDB Cloud easier to understand. The concepts discussed here
+are the three primary components of the Cloud structure: organizations,
+projects, and services.
+
+This is not a full glossary. We intend to provide a more complete glossary in
+the future.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+.. _concepts-orgs:
+
+Organizations
+=============
+
+*Organizations* represent the larger structure - for example a company - within
+which CrateDB Cloud projects and associated services are deployed. At the
+organization level there is always at least one organization administrator, who
+can in turn add organization members. Such organization admins and members have
+access to the projects run by the organization. (For more on user roles in
+CrateDB Cloud and how to set them, see our :ref:`reference for user roles
+<user-roles>`_.)
+
+Each organization has a name, a unique ID, and optionally an associated email
+address. For information on how to create an organization, please refer to
+our `guide to creating a new organization`_.
+
+.. NOTE::
+    Note that currently each CrateDB Cloud user corresponds to only one
+    organization.
+
+
+.. _concepts-projects:
+
+Projects
+========
+
+*Projects* are contained within organizations. A project exists to contain any
+number of associated services deployed in a particular region for a specific
+organizational need. For example, an organization may use distinct projects to
+separate between development and production environments.
+
+A given *organization* can have any number of *projects*. Just as organizations
+have administrators and members, so projects have their own administrators and
+members. The two groups can but need not overlap. (Again, for more on user
+roles in CrateDB Cloud and how to set them, see our :ref:`reference for user
+roles <user-roles>`_.)
+
+Each project has a name, an associated region, and a unique ID. For information
+on how to create a project, please refer to our `guide to creating a new
+project`_.
+
+
+.. _concepts-services:
+
+Services
+========
+
+Within each *project*, a project administrator can deploy any number of
+*services*. One such service is the deployment of clusters, which can be done
+through the CrateDB Cloud Console. A cluster is a set of two or more CrateDB
+instances (referred to as nodes) which form a single, distributed database.
+Effectively, each cluster within CrateDB Cloud is a hosted (part of) a
+database. Depending on the user's subscription plan and scaling, each cluster
+will have a certain storage capacity and can process a certain amount of
+ingests and queries per second. Only actual cluster usage - a service within
+CrateDB Cloud - is actually billed.
+
+A cluster has a name, a unique ID, as well as a storage and processing
+capacity and a number of nodes. Note that clusters are also versioned. For
+information on how to deploy a cluster, please see our `tutorial for deploying
+a CrateDB cluster via Azure Marketplace`_.
+
+Clusters are not the only CrateDB Cloud service. Other offered services are -
+for example - the Azure Event Hubs consumer service, which can ingest event
+data from Event Hubs into CrateDB.
+
+
+.. _guide to creating a new organization: https://crate.io/docs/cloud/console/en/latest/create-org.html
+.. _guide to creating a new project: https://crate.io/docs/cloud/console/en/latest/create-project.html
+.. _tutorial for deploying a CrateDB cluster via Azure Marketplace: https://crate.io/docs/cloud/getting-started/en/latest/getting-started/azure-to-cluster/index.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,10 @@ of Things* (IIoT) at scale.
 
 .. rubric:: Table of contents
 
-TODO
+    azure-plans
+    concepts
+    user-roles
+    system-user
 
 
 .. _Crate.io: https://crate.io/

--- a/docs/system-user.rst
+++ b/docs/system-user.rst
@@ -1,0 +1,19 @@
+.. _system-user:
+
+===========
+System user
+===========
+
+This is the Reference article for the CrateDB *system* user for CrateDB Cloud
+customers.
+
+The system user is a database user called '*system*'. In CrateDB Cloud, the
+backend uses this user in order to perform Cloud cluster upgrades, backups and
+scaling functions, among other things.
+
+.. WARNING::
+    The user '*system*' is essential for CrateDB Cloud to function as intended.
+    While it is not normally accessible through the CrateDB Console or the
+    Croud CLI, it can be accessed through the CrateDB Admin UI or any other SQL
+    client. It is important not to edit or delete this user in any way.
+    Otherwise, the functioning of Cloud clusters may be compromised.

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -1,0 +1,46 @@
+.. _user-roles:
+
+==========
+User roles
+==========
+
+An overview of user roles and their privileges for organizations and projects.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+.. _org-roles:
+
+Organization roles
+==================
+
+An *organization admin* can add users to and remove users from an organization.
+Admins can perform all available operations for projects and services. They
+have access to the organization's Audit Log.
+
+Each organization must have at least one admin.
+
+An *organization member* is able to view the list of organization users but
+can't edit, add, or remove users.
+
+They only have access to projects they are part of.
+
+
+.. _project-roles:
+
+Project roles
+=============
+
+A project admin can add users to and remove users from a project. They can also
+perform every available operation inside that project.
+
+.. NOTE::
+
+    This means that an *organization member* who is also a *project admin* can
+    perform all available operations within that project, but not within the
+    organization.
+
+A project member has read-only access to the project.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This PR does two things: it adds new items to the Cloud Docs Reference section and it moves two items from the Cloud Docs Howtos section to Reference. On merger, I will then delete those items from the other Docs repo (meanwhile they'll be duplicated). Note that this includes the 'system user' warning item for the Cloud Docs, to warn users not to delete or edit the system user.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
