### PR TITLE
Fix for outdated links in Cloud Docs Reference section

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -88,6 +88,6 @@ for example - the Azure Event Hubs consumer service, which can ingest event
 data from Event Hubs into CrateDB.
 
 
-.. _guide to creating a new organization: https://crate.io/docs/cloud/console/en/latest/create-org.html
-.. _guide to creating a new project: https://crate.io/docs/cloud/console/en/latest/create-project.html
-.. _tutorial for deploying a CrateDB cluster via Azure Marketplace: https://crate.io/docs/cloud/getting-started/en/latest/getting-started/azure-to-cluster/index.html
+.. _guide to creating a new organization: https://crate.io/docs/cloud/howtos/en/latest/create-org.html
+.. _guide to creating a new project: https://crate.io/docs/cloud/howtos/en/latest/create-project.html
+.. _tutorial for deploying a CrateDB cluster via Azure Marketplace: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/azure-to-cluster/index.html

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -34,8 +34,8 @@ They only have access to projects they are part of.
 Project roles
 =============
 
-A project admin can add users to and remove users from a project. They can also
-perform every available operation inside that project.
+A *project admin* can add users to and remove users from a project. They can
+also perform every available operation inside that project.
 
 .. NOTE::
 
@@ -43,4 +43,4 @@ perform every available operation inside that project.
     perform all available operations within that project, but not within the
     organization.
 
-A project member has read-only access to the project.
+A *project member* has read-only access to the project.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Response to fix list in [this story](https://trello.com/c/Y48g9rpi/365-3-add-tutorial-how-to-guides-to-docs)

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
