### PR TITLE
Adjust documentation for new General Purpose plan

### DIFF
--- a/docs/azure-plans.rst
+++ b/docs/azure-plans.rst
@@ -5,11 +5,11 @@ Azure subscription plans
 ========================
 
 When signing up for the CrateDB Cloud offer on Microsoft Azure Marketplace, you
-have a choice of three different plans. Each of these plans is preconfigured
-for different use cases, depending on how large your product needs are. By
-presenting these plans in terms of ready configurations of database storage,
-memory, and computation capacity, the user is spared the complexity of finding
-exact required hardware combinations themselves.
+have a choice of two different plans. Each plan is preconfigured for different
+use cases, depending on what your product needs are. By presenting plans in
+terms of ready configurations of database storage, memory, and computation
+capacity, the user is spared the complexity of finding the exact required
+hardware combinations themselves.
 
 At the same time, the plans also offer flexibility, since your use case may
 change. Not only is it possible to switch plans, but within a given plan you
@@ -17,7 +17,7 @@ can scale the required capacity for a cluster up or down. In order to make it
 transparent and yet easy to use, this scaling is measured in terms of Database
 Transaction Units (DTUs).
 
-This reference gives a brief description of each plan and subsequently explains
+This reference gives a brief description of the plans and subsequently explains
 the meaning and usage of DTUs for scaling and pricing within each plan. In this
 way, making a suitable and effective choice of plan for CrateDB Cloud's Azure
 offer will become straightforward.
@@ -33,28 +33,23 @@ offer will become straightforward.
 The CrateDB Cloud plans on Azure Marketplace
 ============================================
 
-Currently, CrateDB Cloud's offer on Azure Marketplace provides three different
-plans: **Development**, **General Purpose Basic** and **General Purpose Pro**.
+Currently, CrateDB Cloud's offer on Azure Marketplace provides two different
+plans: **Development** and **General Purpose**.
 
 * The **Development** plan is aimed at users who want to try out what CrateDB
   Cloud has to offer. It offers modest but robust storage, memory, and
   computation capacity. Although intended for setting up trial clusters to
-  evaluate the product, it offers full flexibility: the capacity can be scaled
-  along three scale units. Per scale unit, one DTU is added (or subtracted).
+  evaluate the product, it offers full flexibility and functionality. The
+  capacity can be scaled along three scale units. Per scale unit, one DTU is
+  added (or subtracted).
 
 .. NOTE::
     Note that the Development plan is not covered by 24/7 support.
 
-* The **General Purpose Basic** plan suits all but very large use cases.
-  It offers the intermediate range of storage, memory, and computation
-  capacity. This plan also can currently be scaled between three scale units,
-  each adding (or subtracting) one DTU.
-* Finally, the **General Purpose Pro** plan is intended for users with very
-  large capacity needs. This plan offers very significant storage, memory, and
-  computation capacity, offering up to four times the ingestion and query
-  capacity of the General Purpose Basic plan and up to an order of magnitude
-  greater storage. The General Purpose Pro plan can also currently be scaled
-  between three scale units, each adding (or subtracting) one DTU.
+* The **General Purpose** plan suits all general use cases. This plan offers
+  significant storage, memory, and computation capacity. The General Purpose
+  plan can also currently be scaled between three scale units, each adding (or
+  subtracting) one DTU.
 
 
 .. _azure-plans-dtus:
@@ -72,20 +67,20 @@ that one scale unit = one DTU, and billing is set up so that Crate.io bills
 only for DTUs/hour actually used.
 
 .. NOTE::
-    Note, however, that scale units do not necessarily *start* at 1 DTU; for
-    example the **Development** plan starts at 3 DTUs and then scales up to 5
-    DTUs.
+    Note, however, that scale units do not necessarily *start* at one DTU; for
+    example the **Development** plan starts at three DTUs and then scales up to
+    five DTUs.
 
 Let's break this down further to clarify what each of these statements mean.
 
-As seen above, CrateDB Cloud's Azure offer is divided into three plans. Each
+As seen above, CrateDB Cloud's Azure offer is divided into two plans. Each
 plan has a starting scale (scale unit 1), which can be scaled up to scale unit
 2 or 3. Because the hardware capacity in each plan is different, a scale unit
 in the **Development** plan is of a different size (in terms of storage,
-memory, and computation) than a scale unit in the **General Purpose Pro** plan.
-But scaling within each plan (i.e., between the minimum capacity for that plan
-and the maximum capacity for that plan) is made easy by the division into scale
-units, each of which corresponds to one DTU.
+memory, and computation) than a scale unit in the **General Purpose** plan.
+But scaling within each plan (i.e., scaling between the minimum capacity for
+that plan and the maximum capacity for that plan) is made easy by the division
+into scale units, each of which corresponds to one DTU.
 
 An overview showing the range in terms of capacity of each plan, within which
 the scaling of that plan operates, can be found on the |Azure offer page|.
@@ -99,11 +94,9 @@ compared easily by the user.
 The same principle applies to the pricing. If you scale within a plan, you will
 readily know how much capacity you are getting and also how much you will pay
 per hour. This is because you know the capacity of the plan, the fact that one
-scale unit = one DTU, and the price per DTU/hour for that plan. The pricing in
-DTU/hours used is determined for each scale unit in a plan, so that a given
-number of scale units = a given number of DTUs, which for a given plan produces
-a given price. This provides both flexibility and transparency. The pricing can
-also be estimated through the `pricing calculator`_.
+scale unit = one DTU, and the price per DTU/hour for that plan. This provides
+both flexibility and transparency. The pricing can also be estimated through
+the `pricing calculator`_.
 
 The precise calculations of required hardware capacity, actual usage of that
 hardware, and a corresponding cost are all handled by Crate.io. The user only
@@ -123,14 +116,15 @@ clearly priced and billed.
 
 CrateDB Cloud's Azure offer provides a straightforward approach to such a use
 case. Simply compare the plans on offer. You will quickly identify that the
-desired capacity falls within the **General Purpose Pro** plan, which begins at
+desired capacity falls within the **General Purpose** plan, which begins at
 2000 ingests/sec. and scales in 2000 ingests/sec. units. You therefore
-subscribe to this plan and scale it up 2 times, from 2000 to 6000 ingests/sec.
+subscribe to this plan and scale it up two times, from 2000 to 6000
+ingests/sec.
 
-Now you have a ready **General Purpose Pro** plan for your cluster at scale
+Now you have a ready **General Purpose** plan for your cluster at scale
 unit 3. Since each scale unit is currently simply one DTU, and the **General**
-**Purpose Pro** plan begins at 1 DTU, you will directly know that your total
-cost is 3 DTU/hour of that plan. Of course, as always, only actual usage is
+**Purpose** plan begins at one DTU, you will directly know that your total cost
+is three DTU/hour of that plan. Of course, as always, only actual usage is
 billed.
 
 It is easy to try out different other estimations and their corresponding plans
@@ -146,16 +140,16 @@ For clarity and to prevent confusion, we add here a few notes of caution:
 
 * The correspondence between one scaling unit and one DTU is provisional and
   may change in the future.
-* Remember that not all plans, currently or in the future, necessarily start at
-  1 DTU. The **Development** plan currently starts at 3 DTU of that plan. When
-  referring to the pricing per DTU/hour on the Azure offer, keep this in mind.
-  This means the price for 1 DTU/hour listed on the Azure offer is not
-  necessarily the minimum price for a given plan, even when one does not scale
-  further upwards, since one may start at several DTUs even without scaling
-  further.
+* Remember that not all plans, currently or in the future, necessarily *start*
+  at one DTU. The **Development** plan currently starts at three DTUs of that
+  plan. Therefore, when referring to the pricing per DTU/hour on the Azure
+  offer, keep this in mind. This means the price for a single DTU/hour, as
+  listed on the Azure offer page, is not necessarily the minimum price for a
+  given plan. This is true even if you do not scale further upwards, since your
+  plan may start at several DTUs even without you scaling it up further.
 * New plans will be offered in the future with different capacity ranges that
-  may suit your use case. Our price calculator and this Reference will then be
-  updated accordingly. Plan terms and prices are subject to change.
+  may suit your use case. Our price calculator and this reference document will
+  then be updated accordingly. Plan terms and prices are subject to change.
 
 
 .. _pricing calculator: https://crate.io/products/cratedb-cloud/#cloud-calculator

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -4,12 +4,12 @@
 Glossary
 ========
 
-This Reference article is a glossary. It is meant to provide a general overview
+This reference article is a glossary. It is meant to provide a general overview
 of terms common to CrateDB Cloud. Because it forms a counterpart to the
 Glossary for CrateDB, we mainly cover terms here that are specific or primary
 to CrateDB Cloud; terms particular to the whole CrateDB architecture will
-appear in the CrateDB Glossary instead. We hope this glossary will help you
-understand the basic meaning of concepts in the CrateDB Console, Documentation,
+appear in the CrateDB glossary instead. We hope this glossary will help you
+understand the basic meaning of concepts in the CrateDB Console, documentation,
 the Croud CLI, and other CrateDB Cloud-related sources. It is not meant to be a
 general guide to IT or IIoT terminology.
 
@@ -44,7 +44,7 @@ Azure AD
 Azure AD (Active Directory) is Microsoft's authentication and sign-in service
 for accessing Microsoft hosted services. CrateDB Cloud uses AzureAD as one of
 the means of sign-up and authentication for its service. For documentation on
-Azure AD, refer to the |Microsoft Documentation|.
+Azure AD, refer to the |Microsoft documentation|.
 
 
 .. _glossary-cluster:
@@ -103,14 +103,14 @@ blog`_. Operations on consumers are registered in the :ref:`Audit Log
 Croud
 -----
 
-Croud is the name of the CrateDB Cloud Command Line Interface (CLI). You can
+Croud is the name of the CrateDB Cloud Command-Line Interface (CLI). You can
 use Croud to interact with the :ref:`organization<glossary-org>`,
 :ref:`projects<glossary-project>` and :ref:`products<glossary-product>` you
 have access to. Croud is intended for customers who prefer a CLI to the use of
 a hosted web interface such as the CrateDB Cloud :ref:`Console
 <glossary-console>`. Note however that the Console is the default way to
 interact with CrateDB Cloud, and currently clusters can only be deployed within
-the Console. The Documentation for Croud can be found under the `Croud CLI
+the Console. The documentation for Croud can be found under the `Croud CLI
 header`_ in the Docs sidebar.
 
 
@@ -128,7 +128,7 @@ plan and see how it matches their use case. This makes using the CrateDB Cloud
 :ref:`offer<glossary-offer>` and scaling to need easy and accessible.
 
 For a more detailed description of the Azure plans and associated DTUs, refer
-to our :ref:`Documentation<azure-plans>`.
+to our :ref:`documentation<azure-plans>`.
 
 
 .. _glossary-endpoint:
@@ -271,16 +271,16 @@ Azure Marketplace|.
 Scale unit
 ----------
 
-The CrateDB Cloud :ref:`subscription plans<glossary-subscription-plan>` all
+The CrateDB Cloud :ref:`subscription plans<glossary-subscription-plan>` each
 come with a number of different scale units. Each scale unit represents an
 (additional) unit multiplying the specific combination of hardware capacity
 that applies to that plan.
 
 The relationship between scale units and :ref:`DTUs<glossary-DTU>` is subtle.
 Each scale unit added on top of the first scale unit also represents one
-*additional* DTU. However, not all plans *start* at 1 DTU. For more detailed
+*additional* DTU. However, not all plans *start* at one DTU. For more detailed
 information about subscription plans, scale units, and DTUs, take a look at our
-Documentation on :ref:`DTUs and Azure plans<azure-plans-dtus>`.
+documentation on :ref:`DTUs and Azure plans<azure-plans-dtus>`.
 
 
 .. _glossary-subscription:
@@ -312,9 +312,9 @@ plans. These plans are combinations of hardware specifications that are geared
 towards particular customer use cases: lower capacity vs. higher capacity, more
 storage vs. more processing power, and so forth. They can also be further
 adjusted for different :ref:`scale units<glossary-scale-unit>` per plan.
-Currently there are three subscription plans available via the |Microsoft Azure
+Currently there are two subscription plans available via the |Microsoft Azure
 Marketplace|, with more to come in the near future. For more information on
-choosing the right Azure plan, refer to our Documentation `on the subject`_.
+choosing the right Azure plan, refer to our documentation `on the subject`_.
 
 
 .. _glossary-system-user:
@@ -330,7 +330,7 @@ In CrateDB Cloud, there are two distinct system :ref:`users<glossary-user>`:
 
 * The other is the "system" user in the CrateDB backend. For more information
   on this second user, refer to our `explanation`_ in the CrateDB Cloud
-  Reference.
+  reference.
 
 
 .. _glossary-user:
@@ -340,7 +340,7 @@ User
 
 A user in CrateDB Cloud is any individual account authorized to interact with
 some part of an :ref:`organization<glossary-org>`'s assets. Each user has a
-defined role within the organization (see our Reference on `user roles`_) and
+defined role within the organization (see our reference on `user roles`_) and
 is associated with a specific email address.
 
 .. NOTE::
@@ -361,6 +361,6 @@ is associated with a specific email address.
 .. |Microsoft Azure Marketplace| raw:: html
 
     <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=PlansAndPrice" target="_blank">Microsoft Azure Marketplace</a>
-.. |Microsoft Documentation| raw:: html
+.. |Microsoft documentation| raw:: html
 
     <a href="https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-whatis" target="_blank">Microsoft Documentation</a>

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -7,10 +7,10 @@ Console overview
 The *CrateDB Cloud Console* is a hosted web administration interface for
 interacting with `CrateDB Cloud`_. This overview gives you all the basic
 information for using the CrateDB Cloud Console. Refer to individual items in
-the current section of the Documentation for more information on how to perform
+the current section of the documentation for more information on how to perform
 specific operations. To understand more of the Console terminology used here,
-refer to the Documentation page on `concepts`_. You can also refer to our
-`Glossary`_ for more information on specific terminology.
+refer to the documentation page on `concepts`_. You can also refer to our
+`glossary`_ for more information on specific terminology.
 
 .. rubric:: Table of contents
 
@@ -94,7 +94,7 @@ If you are an organization admin, you can edit these by clicking the pen icon
 or delete users by using the bin icon. To add new users to the organization, in
 this tab, click the *Add user* button in the top right.
 
-To learn more about user roles and their meaning, see our Documentation on
+To learn more about user roles and their meaning, see our documentation on
 `user roles`_.
 
 
@@ -138,7 +138,7 @@ the main Projects page.
     The menu bar on the left hand side of the Console is divided in two by a
     line. By design, all menu items below the bar refer to the currently
     selected project, which is visible at the top left. The next sections of
-    this Documentation are therefore project specific and here referred to as
+    this documentation are therefore project specific and here referred to as
     "Project Overview", "Project Settings" etc. For elegance of design,
     however, the menu bar simply says "Overview", "Settings", and so forth.
     These each refer to the project you selected on the Projects page.
@@ -185,7 +185,7 @@ It gives you the following information:
   icon gives relevant information on ports and access methods. By clicking on
   the URL you will be redirected to the `CrateDB Admin UI`_ for the cluster at
   that URL. For more information on the protocols used to connect to the
-  respective ports, refer to the CrateDB Documentation on `HTTP`_ and the
+  respective ports, refer to the CrateDB documentation on `HTTP`_ and the
   `PostgreSQL wire protocol`_ as well as the documentation of your client.
 
 .. NOTE::
@@ -205,7 +205,7 @@ It gives you the following information:
 * **Created**: The timestamp of the deployment of the cluster.
 
 * **Tier**: This shows what tier of the pricing plan the cluster is running on.
-  For more information on our pricing plans, see the Documentation on `Azure
+  For more information on our pricing plans, see the documentation on `Azure
   plans`_.
 
 * **RAM/Heap Size**: The currently allocated memory for the cluster.
@@ -225,7 +225,7 @@ It gives you the following information:
   process.
 
 For more information on some of the terminology used here, refer to the
-`CrateDB architecture Documentation`_.
+`CrateDB architecture documentation`_.
 
 
 .. _overview-cluster-metrics:
@@ -334,10 +334,10 @@ Cloud Console.
 .. _bregenz.a1.cratedb.cloud: https://bregenz.a1.cratedb.cloud/
 .. _concepts: https://crate.io/docs/cloud/reference/en/latest/concepts.html
 .. _CrateDB Admin UI: https://crate.io/docs/clients/admin-ui/
-.. _CrateDB architecture Documentation: https://crate.io/docs/crate/howtos/en/latest/architecture/shared-nothing.html
+.. _CrateDB architecture documentation: https://crate.io/docs/crate/howtos/en/latest/architecture/shared-nothing.html
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _eastus2.azure.cratedb.cloud: https://eastus2.azure.cratedb.cloud/
-.. _Glossary: https://crate.io/docs/cloud/reference/en/latest/glossary.html
+.. _glossary: https://crate.io/docs/cloud/reference/en/latest/glossary.html
 .. _HTTP: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
 .. _PostgreSQL wire protocol: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html
 .. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/index.html

--- a/docs/price-calculator.rst
+++ b/docs/price-calculator.rst
@@ -57,13 +57,12 @@ inputs for these specifications:
 
     Short descriptions of each of these inputs are also found as tooltips on
     each next to the pricing calculator itself. For more information on the
-    meaning of technical terms used here, please see our Glossary.
+    meaning of technical terms used here, please see our `glossary`_.
 
 Based on your selected values for each of the inputs, the pricing calculator
-automatically selects for you the most fitting plan configuration (currently
-only within General Purpose) and gives an estimate for the price of the plan
-per hour and per month. As always, only actual usage will be billed on an
-hourly rate basis.
+automatically selects for you the most fitting plan configuration and gives an
+estimate for the price of the plan per hour and per month. As always, only
+actual usage will be billed on the basis of an hourly rate.
 
 
 .. _price-calculator-provider:
@@ -113,10 +112,11 @@ hours) × 24 (hours to days) × 14 (data retention) × 3 (replicas: original plu
 two copies) = 3628800000, divided by 1000000 = 3628.8 GB of storage
 requirements. Based on the read query value and the storage requirements, the
 pricing calculator will recommend a plan and a scale level for that plan. In
-our example case, that would be General Purpose Pro at scale unit 1 on Azure.
+our example case, that would be General Purpose at scale unit 1 on Azure.
 
 More information about plans and scale levels can be found in :ref:`our
 reference on Azure plans <azure-plans>`.
 
 
+.. _glossary: https://crate.io/docs/cloud/reference/en/latest/glossary.html
 .. _price calculator: https://crate.io/products/cratedb-cloud/#cloud-calculator

--- a/docs/system-user.rst
+++ b/docs/system-user.rst
@@ -4,7 +4,7 @@
 System user
 ===========
 
-This is the Reference article for the CrateDB *system* user for CrateDB Cloud
+This is the reference article for the CrateDB *system* user for CrateDB Cloud
 customers.
 
 The system user is a database user called '*system*'. In CrateDB Cloud, the


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This PR accomplishes three things:
- It adjusts the documentation to reflect the dropping of the Azure General Purpose Basic plan in favor of just having General Purpose Pro, to be renamed simply "General Purpose";
- It removes capitalization of internal documentation names in this repo (per tech writing discussion)
- It slightly improves the wording in the Azure Plans document to make it clearer

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
