### PR TITLE
Edit of reference documentation to reflect AWS Marketplace integration throughout

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -65,7 +65,7 @@ ingests and queries per second. Only actual cluster usage is billed.
 A cluster has a name, a unique ID, as well as a storage and processing
 capacity and a number of nodes. Note that clusters are also versioned. For
 information on how to deploy a cluster, please see our `tutorial for deploying
-a CrateDB cluster via Azure Marketplace`_.
+a CrateDB Cloud cluster from scratch`_.
 
 
 .. _glossary-console:
@@ -81,7 +81,7 @@ interacting with the service, we assume use of the Console by default. Only the
 Console allows deployment of a :ref:`cluster<glossary-cluster>`.
 
 For information on how to use specific elements of the Console, refer to our
-`Howtos`_.
+`Console overview`_.
 
 
 .. _glossary-consumer:
@@ -127,8 +127,8 @@ configuration themselves, but can simply identify the price per DTU for a given
 plan and see how it matches their use case. This makes using the CrateDB Cloud
 :ref:`offer<glossary-offer>` and scaling to need easy and accessible.
 
-For a more detailed description of the Azure plans and associated DTUs, refer
-to our :ref:`documentation<azure-plans>`.
+For a more detailed description of the subscription plans and associated DTUs,
+refer to our :ref:`documentation<subscription-plans>`.
 
 
 .. _glossary-endpoint:
@@ -178,8 +178,8 @@ Offer
 
 An offer or subscription offer is a Software-as-a-Service (:ref:`SaaS
 <glossary-saas>`) product prepared for consumer purchase on a subscription
-basis. CrateDB Cloud has an offer on the |Microsoft Azure Marketplace| and is
-preparing an offer on AWS.
+basis. CrateDB Cloud has an offer on the |Microsoft Azure Marketplace| and on
+the `AWS Marketplace`_.
 
 .. _glossary-org:
 
@@ -250,7 +250,7 @@ Region
 
 A region in the sense used for CrateDB Cloud is a set of data centers (servers)
 grouped together on a geographic basis so as to not exceed a certain latency.
-CrateDB Cloud currently has three regions by default, but also offers the
+CrateDB Cloud currently has four regions by default, but also offers the
 option to define custom regions.
 
 
@@ -263,7 +263,7 @@ SaaS stands for "Software-as-a-Service". It refers to a model where software is
 provided to customers on a :ref:`subscription<glossary-subscription>` basis,
 rather than a one-off payment, and is centrally hosted. CrateDB Cloud can be
 used as a service through its SaaS :ref:`offer<glossary-offer>` on |Microsoft
-Azure Marketplace|.
+Azure Marketplace| and the `AWS Marketplace`_.
 
 
 .. _glossary-scale-unit:
@@ -280,7 +280,7 @@ The relationship between scale units and :ref:`DTUs<glossary-DTU>` is subtle.
 Each scale unit added on top of the first scale unit also represents one
 *additional* DTU. However, not all plans *start* at one DTU. For more detailed
 information about subscription plans, scale units, and DTUs, take a look at our
-documentation on :ref:`DTUs and Azure plans<azure-plans-dtus>`.
+documentation on :ref:`DTUs and subscription plans<subscription-plans-dtus>`.
 
 
 .. _glossary-subscription:
@@ -289,17 +289,17 @@ Subscription
 ------------
 
 A subscription is - for the purposes of CrateDB Cloud - a container in which
-the CrateDB Cloud service is created and managed, supported by our cloud
-provider, Microsoft Azure. In other words, once a customer signs up for the
-CrateDB Cloud :ref:`offer<glossary-offer>` and a particular CrateDB Cloud
-:ref:`subscription plan<glossary-subscription-plan>`, they will have a
-subscription to CrateDB Cloud with Azure.
+the CrateDB Cloud service is created and managed, supported by one of our cloud
+providers. In other words, once a customer signs up for a CrateDB Cloud
+:ref:`offer<glossary-offer>` and a particular CrateDB Cloud :ref:`subscription
+plan<glossary-subscription-plan>` via one of our cloud providers, they will
+have a subscription to CrateDB Cloud through that particular cloud provider.
 
 The billing for that particular instance of the CrateDB Cloud service is
-managed per subscription. A given customer (say, a company) can have multiple
-subscriptions. This can be practical in case a customer wants to separate
-different instances of using the CrateDB Cloud service into different billing
-accounts.
+managed per subscription. On Microsoft Azure, a given customer can have
+multiple subscriptions. This can be practical in case that customer wants to
+separate different instances of using the CrateDB Cloud service into different
+billing accounts.
 
 
 .. _glossary-subscription-plan:
@@ -312,9 +312,9 @@ plans. These plans are combinations of hardware specifications that are geared
 towards particular customer use cases: lower capacity vs. higher capacity, more
 storage vs. more processing power, and so forth. They can also be further
 adjusted for different :ref:`scale units<glossary-scale-unit>` per plan.
-Currently there are two subscription plans available via the |Microsoft Azure
-Marketplace|, with more to come in the near future. For more information on
-choosing the right Azure plan, refer to our documentation `on the subject`_.
+Currently there are two subscription plans available on our cloud offers, with
+more to come in the near future. For more information on choosing the right
+subscription plan, refer to our documentation `on the subject`_.
 
 
 .. _glossary-system-user:
@@ -348,15 +348,16 @@ is associated with a specific email address.
     organization.
 
 
-.. _Croud CLI  header: https://crate.io/docs/cloud/cli/en/latest/index.html
+.. _AWS Marketplace: https://aws.amazon.com/marketplace/pp/B089M4B1ND
+.. _Console overview: https://crate.io/docs/cloud/reference/en/latest/overview.html
+.. _Croud CLI header: https://crate.io/docs/cloud/cli/en/latest/index.html
 .. _Croud documentation: https://crate.io/docs/cloud/cli/en/latest/configuration.html#manage-configuration-via-cli
 .. _explanation: https://crate.io/docs/cloud/reference/en/latest/system-user.html
 .. _guide to creating a new organization: https://crate.io/docs/cloud/howtos/en/latest/create-org.html
 .. _guide to creating a new project: https://crate.io/docs/cloud/howtos/en/latest/create-project.html
-.. _Howtos: https://crate.io/docs/cloud/howtos/en/latest/
-.. _on the subject: https://crate.io/docs/cloud/reference/en/latest/azure-plans.html
+.. _on the subject: https://crate.io/docs/cloud/reference/en/latest/subscription-plans.html
 .. _this article on our blog: https://crate.io/a/connecting-azure-iot-hub-and-cratedb-cloud-for-the-ingestion-of-sensor-data/
-.. _tutorial for deploying a CrateDB cluster via Azure Marketplace: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/azure-to-cluster/index.html
+.. _tutorial for deploying a CrateDB Cloud cluster from scratch: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _user roles: https://crate.io/docs/cloud/reference/en/latest/user-roles.html
 .. |Microsoft Azure Marketplace| raw:: html
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ of Things* (IIoT) at scale.
     :titlesonly:
 
     overview
-    azure-plans
+    subscription-plans
     price-calculator
     user-roles
     system-user

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -29,23 +29,24 @@ You must access the Cloud Console by |region|.
 
 Available regions:
 
-+-------------------+-----------------------------------+
-| Region            | URL                               |
-+===================+===================================+
-| Azure East-US2    | `eastus2.azure.cratedb.cloud`_    |
-+-------------------+-----------------------------------+
-| Azure West-Europe | `westeurope.azure.cratedb.cloud`_ |
-+-------------------+-----------------------------------+
-| Bregenz           | `bregenz.a1.cratedb.cloud`_       |
-+-------------------+-----------------------------------+
++-------------------+-------------------------------------+
+| Region            | URL                                 |
++===================+=====================================+
+| AWS West Europe   | `eks1.eu-west-1.aws.cratedb.cloud`_ |
++-------------------+-------------------------------------+
+| Azure East-US2    | `eastus2.azure.cratedb.cloud`_      |
++-------------------+-------------------------------------+
+| Azure West-Europe | `westeurope.azure.cratedb.cloud`_   |
++-------------------+-------------------------------------+
+| Bregenz           | `bregenz.a1.cratedb.cloud`_         |
++-------------------+-------------------------------------+
 
 Azure East-US2 and Azure West-Europe are managed by |Microsoft Azure|. The
-Bregenz region is managed by Crate.io and is located in Austria.
+Bregenz region is managed by Crate.io and is located in Austria. The AWS region
+is managed by AWS and is located in Ireland.
 
-Azure East-US2 is a good default region if you don't know which one to pick.
-
-From the Cloud Console homepage, you can sign in using your Cloud Console
-username and password or using Microsoft Azure *Active Directory* (AD).
+From the Cloud Console homepage, you can `sign in`_ using your Cloud Console
+username and password (Cognito) or using Microsoft Azure *Active Directory*.
 
 If you don't have a Cloud Console account yet, select the sign-in option you
 wish to use. From there, you will be given the option to sign up.
@@ -329,17 +330,19 @@ Use the Logout button to log out of your current account and leave the CrateDB
 Cloud Console.
 
 
-.. _an organization  admin: https://crate.io/docs/cloud/reference/en/latest/user-roles.html#organization-roles
-.. _Azure   plans: https://crate.io/docs/cloud/reference/en/latest/azure-plans.html
+.. _an organization admin: https://crate.io/docs/cloud/reference/en/latest/user-roles.html#organization-roles
+.. _Azure plans: https://crate.io/docs/cloud/reference/en/latest/azure-plans.html
 .. _bregenz.a1.cratedb.cloud: https://bregenz.a1.cratedb.cloud/
 .. _concepts: https://crate.io/docs/cloud/reference/en/latest/concepts.html
 .. _CrateDB Admin UI: https://crate.io/docs/clients/admin-ui/
 .. _CrateDB architecture documentation: https://crate.io/docs/crate/howtos/en/latest/architecture/shared-nothing.html
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _eastus2.azure.cratedb.cloud: https://eastus2.azure.cratedb.cloud/
+.. _eks1.eu-west-1.aws.cratedb.cloud: https://eks1.eu-west-1.aws.cratedb.cloud
 .. _glossary: https://crate.io/docs/cloud/reference/en/latest/glossary.html
 .. _HTTP: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
 .. _PostgreSQL wire protocol: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html
+.. _sign in: https://crate.io/docs/cloud/tutorials/en/latest/sign-up.html
 .. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/index.html
 .. _user roles: https://crate.io/docs/cloud/reference/en/latest/user-roles.html
 .. _westeurope.azure.cratedb.cloud: https://westeurope.azure.cratedb.cloud/

--- a/docs/price-calculator.rst
+++ b/docs/price-calculator.rst
@@ -42,7 +42,7 @@ inputs for these specifications:
 * The expected number **read queries** per second. This represents a
   multiplication of the number of data points to be queried, their update
   frequency (per second), and the number of representations of each data point.
-  
+
 * The estimated average payload size, in kilobytes (kb).
 
 * The desired **data retention** policy, in days. This is the number of days a
@@ -71,8 +71,7 @@ The Cloud provider
 ==================
 
 The Cloud provider specifies the provider of the Cloud subscription. Currently
-we only support Azure subscriptions. We intend to expand this to Amazon Web
-Services (AWS) in the future.
+we support Microsoft Azure and AWS as cloud providers.
 
 
 .. _price-calculator-example:
@@ -112,10 +111,10 @@ hours) × 24 (hours to days) × 14 (data retention) × 3 (replicas: original plu
 two copies) = 3628800000, divided by 1000000 = 3628.8 GB of storage
 requirements. Based on the read query value and the storage requirements, the
 pricing calculator will recommend a plan and a scale level for that plan. In
-our example case, that would be General Purpose at scale unit 1 on Azure.
+our example case, that would be General Purpose at scale unit 1.
 
 More information about plans and scale levels can be found in :ref:`our
-reference on Azure plans <azure-plans>`.
+reference on subscription plans <subscription-plans>`.
 
 
 .. _glossary: https://crate.io/docs/cloud/reference/en/latest/glossary.html

--- a/docs/subscription-plans.rst
+++ b/docs/subscription-plans.rst
@@ -1,15 +1,15 @@
-.. _azure-plans:
+.. _subscription-plans:
 
-========================
-Azure subscription plans
-========================
+==================
+Subscription plans
+==================
 
-When signing up for the CrateDB Cloud offer on Microsoft Azure Marketplace, you
-have a choice of two different plans. Each plan is preconfigured for different
-use cases, depending on what your product needs are. By presenting plans in
-terms of ready configurations of database storage, memory, and computation
-capacity, the user is spared the complexity of finding the exact required
-hardware combinations themselves.
+When signing up for the CrateDB Cloud offer on the marketplace of our cloud
+providers, you have a choice of two different plans. Each plan is preconfigured
+for different use cases, depending on what your product needs are. By
+presenting plans in terms of ready-made configurations of database storage,
+memory, and computation capacity, the customer is spared the complexity of
+finding the exact required hardware combinations themselves.
 
 At the same time, the plans also offer flexibility, since your use case may
 change. Not only is it possible to switch plans, but within a given plan you
@@ -19,8 +19,8 @@ Transaction Units (DTUs).
 
 This reference gives a brief description of the plans and subsequently explains
 the meaning and usage of DTUs for scaling and pricing within each plan. In this
-way, making a suitable and effective choice of plan for CrateDB Cloud's Azure
-offer will become straightforward.
+way, making a suitable and effective choice of plan for CrateDB Cloud's cloud
+offers will become straightforward.
 
 .. rubric:: Table of contents
 
@@ -28,13 +28,14 @@ offer will become straightforward.
    :local:
 
 
-.. _azure-plans-overview:
+.. _subscription-plans-overview:
 
-The CrateDB Cloud plans on Azure Marketplace
-============================================
+The CrateDB Cloud subscription plans
+====================================
 
-Currently, CrateDB Cloud's offer on Azure Marketplace provides two different
-plans: **Development** and **General Purpose**.
+Currently, CrateDB Cloud's offers on `Azure Marketplace`_ and
+`AWS Marketplace`_ come with two different subscription plans: **Development**
+and **General Purpose**.
 
 * The **Development** plan is aimed at users who want to try out what CrateDB
   Cloud has to offer. It offers modest but robust storage, memory, and
@@ -52,19 +53,19 @@ plans: **Development** and **General Purpose**.
   subtracting) one DTU.
 
 
-.. _azure-plans-dtus:
+.. _subscription-plans-dtus:
 
 Explaining DTUs for scaling and billing
 =======================================
 
 What are DTUs and how do they work? As mentioned above, to make finding the
 right combination of hardware capacity more tractable and accessible, CrateDB
-Cloud's offer on Azure uses DTUs. These DTUs have essentially two purposes:
-they allow the user to choose the right combination of plan and scale to find
-the capacity they need, and they provide clarity for the purposes of pricing.
-In order to keep things simple, scaling in each plan is currently set up so
-that one scale unit = one DTU, and billing is set up so that Crate.io bills
-only for DTUs/hour actually used.
+Cloud's offers use DTUs. These DTUs have essentially two purposes: they allow
+the user to choose the right combination of plan and scale to find the capacity
+they need, and they provide clarity for the purposes of pricing. In order to
+keep things simple, scaling in each plan is currently set up so that one scale
+unit = one DTU, and billing is set up so that Crate.io bills only for DTUs/hour
+actually used.
 
 .. NOTE::
     Note, however, that scale units do not necessarily *start* at one DTU; for
@@ -73,18 +74,19 @@ only for DTUs/hour actually used.
 
 Let's break this down further to clarify what each of these statements mean.
 
-As seen above, CrateDB Cloud's Azure offer is divided into two plans. Each
-plan has a starting scale (scale unit 1), which can be scaled up to scale unit
-2 or 3. Because the hardware capacity in each plan is different, a scale unit
-in the **Development** plan is of a different size (in terms of storage,
-memory, and computation) than a scale unit in the **General Purpose** plan.
-But scaling within each plan (i.e., scaling between the minimum capacity for
-that plan and the maximum capacity for that plan) is made easy by the division
-into scale units, each of which corresponds to one DTU.
+As seen above, CrateDB Cloud's cloud offer is divided into two plans. Each plan
+has a starting scale (scale unit 1), which can be scaled up to scale unit 2 or
+3. Because the hardware capacity in each plan is different, a scale unit in the
+**Development** plan is of a different size (in terms of storage, memory, and
+computation) than a scale unit in the **General Purpose** plan. But scaling
+within each plan (i.e., scaling between the minimum capacity for that plan and
+the maximum capacity for that plan) is made easy by the division into scale
+units, each of which corresponds to one DTU.
 
 An overview showing the range in terms of capacity of each plan, within which
-the scaling of that plan operates, can be found on the |Azure offer page|.
-Here one also finds the price per DTU per hour.
+the scaling of that plan operates, can be found on the |Azure offer page| and
+the `AWS offer page`_ respectively. Here one also finds the price per DTU per
+hour.
 
 To summarize, the DTU approach to scaling means that although the offered plans
 differ considerably in capacity both between each other and per scale unit
@@ -114,7 +116,7 @@ second and want corresponding capacity in storage, without having to worry
 about the precise storage size. Also, you want this to be easy to set up and
 clearly priced and billed.
 
-CrateDB Cloud's Azure offer provides a straightforward approach to such a use
+CrateDB Cloud's cloud offers provide a straightforward approach to such a use
 case. Simply compare the plans on offer. You will quickly identify that the
 desired capacity falls within the **General Purpose** plan, which begins at
 2000 ingests/sec. and scales in 2000 ingests/sec. units. You therefore
@@ -142,9 +144,9 @@ For clarity and to prevent confusion, we add here a few notes of caution:
   may change in the future.
 * Remember that not all plans, currently or in the future, necessarily *start*
   at one DTU. The **Development** plan currently starts at three DTUs of that
-  plan. Therefore, when referring to the pricing per DTU/hour on the Azure
+  plan. Therefore, when referring to the pricing per DTU/hour on the cloud
   offer, keep this in mind. This means the price for a single DTU/hour, as
-  listed on the Azure offer page, is not necessarily the minimum price for a
+  listed on the cloud offer pages, is not necessarily the minimum price for a
   given plan. This is true even if you do not scale further upwards, since your
   plan may start at several DTUs even without you scaling it up further.
 * New plans will be offered in the future with different capacity ranges that
@@ -152,6 +154,9 @@ For clarity and to prevent confusion, we add here a few notes of caution:
   then be updated accordingly. Plan terms and prices are subject to change.
 
 
+.. _AWS Marketplace: https://aws.amazon.com/marketplace/pp/B089M4B1ND
+.. _AWS offer page: https://aws.amazon.com/marketplace/pp/B089M4B1ND
+.. _Azure Marketplace: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=PlansAndPrice
 .. _pricing calculator: https://crate.io/products/cratedb-cloud/#cloud-calculator
 .. _price calculator on the CrateDB Cloud website: https://crate.io/products/cratedb-cloud/#cloud-calculator
 .. |Azure offer page| raw:: html


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Renames 'Azure plans' to 'subscription plans' throughout, since Azure is no longer the default (or indeed only) option
- References to Azure as the cloud provider changed to reflect choice of Azure and AWS
- Links updated
- Region list updated
- Some rewrites for clarity

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
