### PR TITLE
Refresh: update Cloud reference to reflect Stripe integration

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -261,9 +261,10 @@ SaaS
 
 SaaS stands for "Software-as-a-Service". It refers to a model where software is
 provided to customers on a :ref:`subscription<glossary-subscription>` basis,
-rather than a one-off payment, and is centrally hosted. CrateDB Cloud can be
-used as a service through its SaaS :ref:`offer<glossary-offer>` on `Microsoft
-Azure Marketplace`_ and the `AWS Marketplace`_.
+rather than a one-off payment, and is centrally hosted. Besides the default
+option of subscribing directly, CrateDB Cloud can be used as a service
+through its SaaS :ref:`offer<glossary-offer>` on `Microsoft Azure Marketplace`_
+and the `AWS Marketplace`_.
 
 
 .. _glossary-scale-unit:
@@ -289,17 +290,17 @@ Subscription
 ------------
 
 A subscription is - for the purposes of CrateDB Cloud - a container in which
-the CrateDB Cloud service is created and managed, supported by one of our cloud
-providers. In other words, once a customer signs up for a CrateDB Cloud
-:ref:`offer<glossary-offer>` and a particular CrateDB Cloud :ref:`subscription
-plan<glossary-subscription-plan>` via one of our cloud providers, they will
-have a subscription to CrateDB Cloud through that particular cloud provider.
+the CrateDB Cloud service is created and managed. You can purchase a CrateDB
+Cloud subscription by following the steps in our `tutorial`_. In the case of
+our :ref:`SaaS<glossary-saas>` :ref:`offers<glossary-offer>` on the cloud
+provider marketplaces, customers subscribe to CrateDB Cloud through that
+particular cloud provider.
 
-The billing for that particular instance of the CrateDB Cloud service is
-managed per subscription. On Microsoft Azure, a given customer can have
-multiple subscriptions. This can be practical in case that customer wants to
-separate different instances of using the CrateDB Cloud service into different
-billing accounts.
+The billing for a particular instance of the CrateDB Cloud service is managed
+per subscription. On Microsoft Azure, a given customer can have multiple
+subscriptions. This can be practical in case that customer wants to separate
+different instances of using the CrateDB Cloud service into different billing
+accounts.
 
 
 .. _glossary-subscription-plan:
@@ -307,15 +308,14 @@ billing accounts.
 Subscription plan
 -----------------
 
-CrateDB Cloud's :ref:`offer<glossary-offer>` consists of multiple subscription
-plans. These plans are combinations of hardware specifications that are geared
-towards particular customer use cases: lower capacity vs. higher capacity, more
-storage vs. more processing power, and so forth. They can also be further
-adjusted for different :ref:`scale units<glossary-scale-unit>` per plan.
-Currently there are four subscription plans available on our cloud offers, with
-more to come in the near future, as well as a contract offer. For more
-information on choosing the right subscription plan, refer to our documentation
-on `subscription plans`_.
+CrateDB Cloud's service comes with several possible subscription plans. These
+plans are combinations of hardware specifications that are geared towards
+particular customer use cases: lower capacity vs. higher capacity, more storage
+vs. more processing power, and so forth. They can also be further adjusted for
+different :ref:`scale units<glossary-scale-unit>` per plan. Currently there are
+four subscription plans available, as well as a separate contract option via
+our marketplace :ref:`offers<glossary-offer>`. For more information, refer to
+our documentation on `subscription plans`_.
 
 
 .. _glossary-system-user:
@@ -358,5 +358,6 @@ defined role within the organization (see our reference on :ref:`user roles
 .. _Microsoft documentation on Azure: https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-whatis
 .. _subscription plans: https://crate.io/docs/cloud/reference/en/latest/subscription-plans.html
 .. _this article on our blog: https://crate.io/a/connecting-azure-iot-hub-and-cratedb-cloud-for-the-ingestion-of-sensor-data/
+.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _tutorial for deploying a CrateDB Cloud cluster from scratch: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _user roles: https://crate.io/docs/cloud/reference/en/latest/user-roles.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,15 +4,10 @@
 CrateDB Cloud Reference
 =======================
 
-`CrateDB Cloud`_ is a fully-managed version of `CrateDB`_ as a service that
-runs in the cloud and is run by experts at `Crate.io`_. CrateDB Cloud provides
-real-time analytics and visualization specialized for the *Industrial Internet
-of Things* (IIoT) at scale.
-
-.. NOTE::
-
-    This resource assumes you know the basics. If not, check out the
-    `Tutorials`_ section for beginner material.
+`CrateDB Cloud`_ is a ready version of `CrateDB`_ as a service that runs in the
+cloud and is managed by the experts at `Crate.io`_. CrateDB Cloud supports
+real-time analytics and visualization specialized for the :ref:`Industrial Internet
+of Things (IIoT)<glossary-iiot>` at scale.
 
 .. SEEALSO::
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -390,5 +390,5 @@ Cloud Console.
 .. _scaling the cluster: https://crate.io/docs/cloud/howtos/en/latest/scale-cluster.html
 .. _signup tutorial: https://crate.io/docs/cloud/tutorials/en/latest/sign-up.html
 .. _subscription plans: https://crate.io/docs/cloud/reference/en/latest/subscription-plans.html
-.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/index.html
+.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _user roles: https://crate.io/docs/cloud/reference/en/latest/user-roles.html

--- a/docs/subscription-plans.rst
+++ b/docs/subscription-plans.rst
@@ -4,12 +4,12 @@
 Subscription plans
 ==================
 
-When signing up for the CrateDB Cloud offer on the marketplace of our cloud
-providers, you have a choice of four different plans. Each plan is
-preconfigured for different use cases, depending on what your product needs
-are. By presenting plans in terms of ready-made configurations of database
-storage, memory, and computation capacity, the customer is spared the
-complexity of finding the exact required hardware combinations themselves.
+When signing up for the CrateDB Cloud service, you have a choice of four
+different plans. Each plan is preconfigured for different use cases, depending
+on what your product needs are. By presenting plans in terms of ready-made
+configurations of database storage, memory, and computation capacity, the
+customer is spared the complexity of finding the exact required hardware
+combinations themselves.
 
 At the same time, the plans also offer flexibility, since your use case may
 change. Not only is it possible to switch plans, but within a given plan you
@@ -18,9 +18,9 @@ transparent and yet easy to use, this scaling is measured in terms of Database
 Transaction Units (DTUs).
 
 This reference gives a brief description of the plans and subsequently explains
-the meaning and usage of DTUs for scaling and pricing within each plan. In this
-way, making a suitable and effective choice of plan for CrateDB Cloud's cloud
-offers will become straightforward.
+the meaning and usage of DTUs for scaling and pricing within each plan. This
+should make it easy to choose the right plan for your CrateDB Cloud
+subscription.
 
 .. rubric:: Table of contents
 
@@ -30,11 +30,10 @@ offers will become straightforward.
 
 .. _subscription-plans-overview:
 
-The CrateDB Cloud subscription plans
-====================================
+CrateDB Cloud subscription plans
+================================
 
-Currently, CrateDB Cloud's offers on `Azure Marketplace`_ and
-`AWS Marketplace`_ come with four different subscription plans:
+CrateDB Cloud's service comes with four different subscription plans:
 **Development**, **General Purpose**, **IO Optimized**, and **Storage
 Optimized**. Besides these, we also offer the CrateDB Cloud **Contract**.
 
@@ -46,7 +45,7 @@ Optimized**. Besides these, we also offer the CrateDB Cloud **Contract**.
   added (or subtracted).
 
 .. NOTE::
-    Note that the Development plan is not covered by 24/7 support.
+    The **Development** plan is not covered by 24/7 support.
 
 * The **General Purpose** plan suits all general use cases. This plan offers
   significant storage, memory, and computation capacity. The General Purpose
@@ -72,7 +71,8 @@ The **CrateDB Cloud Contract** allows you to pay for a full year's worth of the
 service of your choice in advance. You purchase a certain number of DTUs for
 one of the subscription plans mentioned above, and pay them up front for the
 full year. Depending on the specifics of the contract chosen, it may be
-possible to negotiate a discount based on the up front payment. For more
+possible to negotiate a discount based on the up front payment. The CrateDB
+Cloud Contract is only available via our supported cloud providers. For more
 information, contact our `Sales team`_.
 
 The process depends on whether you sign up via Azure or via AWS, as described
@@ -136,14 +136,17 @@ for that plan and the maximum capacity for that plan) is made easy by the
 division into scale units, each of which corresponds to one DTU.
 
 An overview showing the range in terms of capacity of each plan, within which
-the scaling of that plan operates, can be found on the `Azure offer page`_ and
-the `AWS offer page`_ respectively. Here you can also find the price per DTU
-per hour.
+the scaling of that plan operates, can be found on the subscription plan
+overview when subscribing directly via the CrateDB Cloud Console. In the case
+of our cloud providers, the overview can be found on the `Azure offer page`_
+and the `AWS offer page`_, respectively. In each case, you can also find the
+price per DTU/hour for each subscription plan in the same overview.
 
-To summarize, the DTU approach to scaling means that although the offered plans
-differ considerably in capacity both between each other and per scale unit
-within each plan, the DTU system allows these different magnitudes to be
-compared easily by the user.
+To summarize:
+
+The DTU approach to scaling means that although the offered plans differ
+considerably in capacity both between each other and per scale unit within each
+plan, the DTU system allows you to easily compare these different magnitudes.
 
 The same principle applies to the pricing. If you scale within a plan, you will
 readily know how much capacity you are getting and also how much you will pay
@@ -157,7 +160,7 @@ needs to consider a plan, a scale within that plan, and the price in DTU/hour
 that corresponds to it.
 
 
-.. _azure-plans-example:
+.. _subscription-plans-example:
 
 A practical example
 ===================
@@ -167,26 +170,25 @@ second and want corresponding capacity in storage, without having to worry
 about the precise storage size. Also, you want this to be easy to set up and
 clearly priced and billed.
 
-CrateDB Cloud's cloud offers provide a straightforward approach to such a use
-case. Simply compare the plans on offer. You will quickly identify that the
-desired capacity falls within the **General Purpose** plan, which begins at
-2000 ingests/sec. and scales in 2000 ingests/sec. units. You therefore
-subscribe to this plan and scale it up two times, from 2000 to 6000
-ingests/sec.
+CrateDB Cloud provides a straightforward solution to such a use case. Simply
+compare the plans on offer. You will quickly identify that the desired capacity
+falls within the **General Purpose** plan, which begins at 2000 ingests/sec.
+and scales in 2000 ingests/sec. units. You therefore subscribe to this plan and
+scale it up two times, from 2000 to 6000 ingests/sec.
 
 Now you have a ready **General Purpose** plan for your cluster at scale
-unit 3. Since each scale unit is currently simply one DTU, and the **General**
-**Purpose** plan begins at one DTU, you will directly know that your total cost
+unit 3. Since each scale unit is currently simply one DTU, and the **General
+Purpose** plan begins at one DTU, you will directly know that your total cost
 is three DTU/hour of that plan. Of course, as always, only actual usage is
 billed.
 
 
-.. _azure-plans-notes:
+.. _subscription-plans-notes:
 
 Cautionary notes
 ================
 
-For clarity and to prevent confusion, we add here a few notes of caution:
+For clarity, we add here a few notes of caution:
 
 * The correspondence between one scaling unit and one DTU is provisional and
   may change in the future.
@@ -197,14 +199,12 @@ For clarity and to prevent confusion, we add here a few notes of caution:
   listed on the cloud offer pages, is not necessarily the minimum price for a
   given plan. This is true even if you do not scale further upwards, since your
   plan may start at several DTUs even without you scaling it up further.
-* New plans will be offered in the future with different capacity ranges that
+* New plans may be offered in the future with different capacity ranges that
   may suit your use case. This reference document will then be updated
   accordingly. Plan terms and prices are subject to change.
 
 
-.. _AWS Marketplace: https://aws.amazon.com/marketplace/pp/B089M4B1ND
 .. _AWS offer page: https://aws.amazon.com/marketplace/pp/B089M4B1ND
-.. _Azure Marketplace: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=PlansAndPrice
 .. _Azure offer page: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=Overview
 .. _Contract page on the AWS Marketplace: https://aws.amazon.com/marketplace/pp/B08KHK34RK
 .. _initial steps  for signup: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/deploy-to-cluster-azure/signup-azure.html#using-the-cratedb-cloud-offer-on-azure-marketplace


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Reflect Stripe integration (i.e., rephrasing references to cloud providers only, prioritizing our default route, etc.)
- Misc. clarifications and reformulations

NB: Requires a followup PR - when the main Stripe doc PR is merged - in order to link to the correct tutorials for our preferred (credit card) signup path

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
