### PR TITLE
Alter glossary labels to pick up new theme styling when linked to

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -22,21 +22,21 @@ through links. The entries are presented in alphabetical order.
    :local:
 
 
-.. _glossary-audit-log:
+.. _gloss-audit-log:
 
 Audit log
 ---------
 
 The Audit Log registers and displays all operations associated with a
-particular :ref:`organization<glossary-org>`. This includes operations on
-:ref:`users<glossary-user>`, on :ref:`clusters<glossary-cluster>`, on
-:ref:`projects<glossary-project>`, and on :ref:`consumers<glossary-consumer>`.
-The Audit Log can be found in the rightmost tab of the Organization overview
-page in the CrateDB Cloud :ref:`Console<glossary-console>`. Only an
-*organization admin* has access to the Audit Log.
+particular :ref:`organization <gloss-org>`. This includes operations on
+:ref:`users <gloss-user>`, on :ref:`clusters <gloss-cluster>`, on
+:ref:`projects <gloss-project>`, and on :ref:`consumers <gloss-consumer>`. The
+Audit Log can be found in the rightmost tab of the Organization overview page
+in the CrateDB Cloud :ref:`Console <gloss-console>`. Only an *organization
+admin* has access to the Audit Log.
 
 
-.. _glossary-azure-ad:
+.. _gloss-azure-ad:
 
 Azure AD
 --------
@@ -47,116 +47,115 @@ the means of sign-up and authentication for its service. For documentation on
 Azure AD, refer to the `Microsoft documentation on Azure`_.
 
 
-.. _glossary-cluster:
+.. _gloss-cluster:
 
 Cluster
 -------
 
-Within each :ref:`project<glossary-project>`, a project administrator can
-deploy any number of :ref:`products<glossary-product>`. One such service is the
+Within each :ref:`project <gloss-project>`, a project administrator can deploy
+any number of :ref:`products <gloss-product>`. One such service is the
 deployment of clusters, which can be done through the CrateDB Cloud Console. A
 cluster is a set of two or more CrateDB instances (referred to as nodes) which
 form a single, distributed database. Effectively, each cluster within CrateDB
 Cloud is a hosted (part of) a database. Depending on the user's
-:ref:`subscription plan<glossary-subscription-plan>` and scaling, each cluster
+:ref:`subscription plan <gloss-subscription-plan>` and scaling, each cluster
 will have a certain storage capacity and can process a certain amount of
 ingests and queries per second. Only actual cluster usage is billed.
 
-A cluster has a name, a unique ID, as well as a storage and processing
-capacity and a number of nodes. Note that clusters are also versioned. For
-information on how to deploy a cluster, please see our `tutorial for deploying
-a CrateDB Cloud cluster from scratch`_.
+A cluster has a name, a unique ID, as well as a storage and processing capacity
+and a number of nodes. Note that clusters are also versioned. For information
+on how to deploy a cluster, please see our `tutorial for deploying a CrateDB
+Cloud cluster from scratch`_.
 
 
-.. _glossary-console:
+.. _gloss-console:
 
 Console
 -------
 
-The CrateDB Cloud Console is the hosted user interface for CrateDB Cloud. It
-is a fully supported, easy-to-use UI which allows customers to interact with
-every aspect of the CrateDB Cloud service (subject to :ref:`user role
-permissions<user-roles>`.) While CrateDB Cloud also supports a CLI for
-interacting with the service, we assume use of the Console by default. Only the
-Console allows deployment of a :ref:`cluster<glossary-cluster>`.
+The CrateDB Cloud Console is the hosted user interface for CrateDB Cloud. It is
+a fully supported, easy-to-use UI which allows customers to interact with every
+aspect of the CrateDB Cloud service (subject to :ref:`user role permissions
+<user-roles>`.) While CrateDB Cloud also supports a CLI for interacting with
+the service, we assume use of the Console by default. Only the Console allows
+deployment of a :ref:`cluster <gloss-cluster>`.
 
 For information on how to use specific elements of the Console, refer to our
 :ref:`Console overview <overview>`.
 
 
-.. _glossary-consumer:
+.. _gloss-consumer:
 
 Consumer
 --------
 
 A consumer in the sense used for CrateDB Cloud architecture and documentation
-is an entity that reads event data from an :ref:`IoT<glossary-iot>` hub. It is
+is an entity that reads event data from an :ref:`IoT <gloss-iot>` hub. It is
 possible to use a consumer, such as Azure IoT Hub, with CrateDB Cloud: you can
 store the data processed by the consumer on the Cloud :ref:`cluster
-<glossary-cluster>`. For a tutorial on how to do this, see `this article on our
+<gloss-cluster>`. For a tutorial on how to do this, see `this article on our
 blog`_. Operations on consumers are registered in the :ref:`Audit Log
-<glossary-audit-log>`.
+<gloss-audit-log>`.
 
 
-.. _glossary-croud:
+.. _gloss-croud:
 
 Croud
 -----
 
 Croud is the name of the CrateDB Cloud Command-Line Interface (CLI). You can
-use Croud to interact with the :ref:`organization<glossary-org>`,
-:ref:`projects<glossary-project>` and :ref:`products<glossary-product>` you
-have access to. Croud is intended for customers who prefer a CLI to the use of
-a hosted web interface such as the CrateDB Cloud :ref:`Console
-<glossary-console>`. Note however that the Console is the default way to
-interact with CrateDB Cloud, and currently clusters can only be deployed within
-the Console. The documentation for Croud can be found under the `Croud CLI
-header`_ in the Docs sidebar.
+use Croud to interact with the :ref:`organization <gloss-org>`, :ref:`projects
+<gloss-project>` and :ref:`products <gloss-product>` you have access to. Croud
+is intended for customers who prefer a CLI to the use of a hosted web interface
+such as the CrateDB Cloud :ref:`Console <gloss-console>`. Note however that the
+Console is the default way to interact with CrateDB Cloud, and currently
+clusters can only be deployed within the Console. The documentation for Croud
+can be found under the `Croud CLI header`_ in the Docs sidebar.
 
 
-.. _glossary-DTU:
+.. _gloss-DTU:
 
 DTU
 ---
 
 DTU stands for Database Transaction Unit. CrateDB Cloud uses DTUs to create
 configurations (combinations) of hardware specifications for specific
-:ref:`subscription plans<glossary-subscription-plan>`. The advantage is that
-the customer does not need to specify every element of the hardware
-configuration themselves, but can simply identify the price per DTU for a given
-plan and see how it matches their use case. This makes using the CrateDB Cloud
-:ref:`offer<glossary-offer>` and scaling to need easy and accessible.
+:ref:`subscription plans <gloss-subscription-plan>`. The advantage is that the
+customer does not need to specify every element of the hardware configuration
+themselves, but can simply identify the price per DTU for a given plan and see
+how it matches their use case. This makes using the CrateDB Cloud :ref:`offer
+<gloss-offer>` and scaling to need easy and accessible.
 
 For a more detailed description of the subscription plans and associated DTUs,
-refer to our :ref:`documentation<subscription-plans>`.
+refer to our :ref:`documentation <subscription-plans>`.
 
 
-.. _glossary-endpoint:
+.. _gloss-endpoint:
 
 Endpoint
 --------
 
 An endpoint is the end or goal of a communication channel. A user or client
 communicates with an endpoint via a defined method, which returns a defined set
-of data. In CrateDB Cloud, different :ref:`profiles<glossary-profile>` can be
+of data. In CrateDB Cloud, different :ref:`profiles <gloss-profile>` can be
 used to configure their own associated endpoints, which a user connects to via
-the :ref:`Croud<glossary-croud>` CLI. For information on how to do this, see
-the `Croud documentation`_.
+the :ref:`Croud <gloss-croud>` CLI. For information on how to do this, see the
+`Croud documentation`_.
 
 
-.. _glossary-iiot:
+.. _gloss-iiot:
 
 IIoT
 ----
 
 The abbreviation IIoT refers to the "Industrial Internet of Things". It is a
-version of :ref:`IoT<glossary-iot>`, but specifically developed for application
+version of :ref:`IoT <gloss-iot>`, but specifically developed for application
 in industrial manufacturing. In this context, the gathering, transfer, and
 storage of data gathered by digital devices installed on machines supports
 greater efficiency and automation potential in the manufacturing sector.
 
 
-.. _glossary-iot:
+.. _gloss-iot:
 
 IoT
 ---
@@ -168,69 +167,70 @@ communicate with one another without the need for human (inter)action. In IoT
 systems, each digital device is provided with a unique ID and communicates with
 other devices on that basis, in particular for the transfer and receiving of
 data. When used in manufacturing and industrial applications, it is also called
-:ref:`IIoT<glossary-iiot>`.
+:ref:`IIoT <gloss-iiot>`.
 
 
-.. _glossary-offer:
+.. _gloss-offer:
 
 Offer
 -----
 
 An offer or subscription offer is a Software-as-a-Service (:ref:`SaaS
-<glossary-saas>`) product prepared for consumer purchase on a subscription
+<gloss-saas>`) product prepared for consumer purchase on a subscription
 basis. CrateDB Cloud has an offer on the `Microsoft Azure Marketplace`_ and on
 the `AWS Marketplace`_.
 
-.. _glossary-org:
+
+.. _gloss-org:
 
 Organization
 ------------
 
 Organizations represent the larger structure - for example a company - within
-which CrateDB Cloud :ref:`projects<glossary-project>` and associated
-:ref:`products<glossary-product>` are deployed. At the organization level there
+which CrateDB Cloud :ref:`projects <gloss-project>` and associated
+:ref:`products <gloss-product>` are deployed. At the organization level there
 is always at least one organization administrator, who can in turn add
 organization members. Such organization admins and members have access to the
 projects run by the organization. (For more on user roles in CrateDB Cloud and
 how to manage them, see our :ref:`reference for user roles <user-roles>`.)
 
 Each organization has a name, a unique ID, and optionally an associated email
-address. For information on how to create an organization, please refer to
-our `guide to creating a new organization`_.
+address. For information on how to create an organization, please refer to our
+`guide to creating a new organization`_.
 
 
-.. _glossary-product:
+.. _gloss-product:
 
 Product
 -------
 
 A product in the sense used in CrateDB Cloud is something that uses the Cloud
 service for the storage of data. It consists of either a :ref:`consumer
-<glossary-consumer>` or a :ref:`cluster<glossary-cluster>` and is run within a
-:ref:`project<glossary-project>` of an :ref:`organization<glossary-org>`.
+<gloss-consumer>` or a :ref:`cluster <gloss-cluster>` and is run within a
+:ref:`project <gloss-project>` of an :ref:`organization <gloss-org>`.
 
 
-.. _glossary-profile:
+.. _gloss-profile:
 
 Profile
 -------
 
-In CrateDB Cloud's CLI, :ref:`Croud<glossary-croud>`, profiles are sets of
-configuration options. They define API :ref:`endpoints<glossary-endpoint>` and
+In CrateDB Cloud's CLI, :ref:`Croud <gloss-croud>`, profiles are sets of
+configuration options. They define API :ref:`endpoints <gloss-endpoint>` and
 the desired output format of interaction with those endpoints. A Croud user can
 create multiple profiles and switch between them as desired.
 
 
-.. _glossary-project:
+.. _gloss-project:
 
 Project
 -------
 
-A project is contained within an :ref:`organization<glossary-org>`. A project
+A project is contained within an :ref:`organization <gloss-org>`. A project
 exists to contain any number of associated services (see :ref:`products
-<glossary-product>`) deployed in a particular :ref:`region<glossary-region>`
-for a specific organizational need. For example, an organization may use
-distinct projects to separate between development and production environments.
+<gloss-product>`) deployed in a particular :ref:`region <gloss-region>` for a
+specific organizational need. For example, an organization may use distinct
+projects to separate between development and production environments.
 
 A given organization can have any number of projects. Just as organizations
 have administrators and members, so projects have their own administrators and
@@ -243,48 +243,48 @@ on how to create a project, please refer to our `guide to creating a new
 project`_.
 
 
-.. _glossary-region:
+.. _gloss-region:
 
 Region
 ------
 
 A region in the sense used for CrateDB Cloud is a set of data centers (servers)
 grouped together on a geographic basis so as to not exceed a certain latency.
-CrateDB Cloud currently has four regions by default, but also offers the
-option to define custom regions.
+CrateDB Cloud currently has four regions by default, but also offers the option
+to define custom regions.
 
 
-.. _glossary-saas:
+.. _gloss-saas:
 
 SaaS
 ----
 
 SaaS stands for "Software-as-a-Service". It refers to a model where software is
-provided to customers on a :ref:`subscription<glossary-subscription>` basis,
+provided to customers on a :ref:`subscription <gloss-subscription>` basis,
 rather than a one-off payment, and is centrally hosted. Besides the default
-option of subscribing directly, CrateDB Cloud can be used as a service
-through its SaaS :ref:`offer<glossary-offer>` on `Microsoft Azure Marketplace`_
-and the `AWS Marketplace`_.
+option of subscribing directly, CrateDB Cloud can be used as a service through
+its SaaS :ref:`offer <gloss-offer>` on `Microsoft Azure Marketplace`_ and the
+`AWS Marketplace`_.
 
 
-.. _glossary-scale-unit:
+.. _gloss-scale-unit:
 
 Scale unit
 ----------
 
-The CrateDB Cloud :ref:`subscription plans<glossary-subscription-plan>` each
-come with a number of different scale units. Each scale unit represents an
+The CrateDB Cloud :ref:`subscription plans <gloss-subscription-plan>` each come
+with a number of different scale units. Each scale unit represents an
 (additional) unit multiplying the specific combination of hardware capacity
 that applies to that plan.
 
-The relationship between scale units and :ref:`DTUs<glossary-DTU>` is subtle.
+The relationship between scale units and :ref:`DTUs <gloss-DTU>` is subtle.
 Each scale unit added on top of the first scale unit also represents one
 *additional* DTU. However, not all plans *start* at one DTU. For more detailed
 information about subscription plans, scale units, and DTUs, take a look at our
 documentation on :ref:`DTUs and subscription plans<subscription-plans-dtus>`.
 
 
-.. _glossary-subscription:
+.. _gloss-subscription:
 
 Subscription
 ------------
@@ -292,9 +292,9 @@ Subscription
 A subscription is - for the purposes of CrateDB Cloud - a container in which
 the CrateDB Cloud service is created and managed. You can purchase a CrateDB
 Cloud subscription by following the steps in our `tutorial`_. In the case of
-our :ref:`SaaS<glossary-saas>` :ref:`offers<glossary-offer>` on the cloud
-provider marketplaces, customers subscribe to CrateDB Cloud through that
-particular cloud provider.
+our :ref:`SaaS <gloss-saas>` :ref:`offers <gloss-offer>` on the cloud provider
+marketplaces, customers subscribe to CrateDB Cloud through that particular
+cloud provider.
 
 The billing for a particular instance of the CrateDB Cloud service is managed
 per subscription. On Microsoft Azure, a given customer can have multiple
@@ -303,7 +303,7 @@ different instances of using the CrateDB Cloud service into different billing
 accounts.
 
 
-.. _glossary-subscription-plan:
+.. _gloss-subscription-plan:
 
 Subscription plan
 -----------------
@@ -312,39 +312,40 @@ CrateDB Cloud's service comes with several possible subscription plans. These
 plans are combinations of hardware specifications that are geared towards
 particular customer use cases: lower capacity vs. higher capacity, more storage
 vs. more processing power, and so forth. They can also be further adjusted for
-different :ref:`scale units<glossary-scale-unit>` per plan. Currently there are
+different :ref:`scale units <gloss-scale-unit>` per plan. Currently there are
 four subscription plans available, as well as a separate contract option via
-our marketplace :ref:`offers<glossary-offer>`. For more information, refer to
-our documentation on `subscription plans`_.
+our marketplace :ref:`offers <gloss-offer>`. For more information, refer to our
+documentation on `subscription plans`_.
 
 
-.. _glossary-system-user:
+.. _gloss-system-user:
 
 System user
 -----------
 
-In CrateDB Cloud, there are two distinct system :ref:`users<glossary-user>`:
+In CrateDB Cloud, there are two distinct system :ref:`users <gloss-user>`:
 
-* One is the "SYSTEM" user in the :ref:`Audit Log<glossary-audit-log>`. This is
+- One is the "SYSTEM" user in the :ref:`Audit Log <gloss-audit-log>`. This is
   an internal user that logs the results of (attempted) :ref:`scaling
-  <glossary-scale-unit>` operations.
+  <gloss-scale-unit>` operations.
 
-* The other is the "system" user in the CrateDB backend. For more information
+- The other is the "system" user in the CrateDB backend. For more information
   on this second user, refer to our :ref:`explanation <system-user>` in the
   CrateDB Cloud reference.
 
 
-.. _glossary-user:
+.. _gloss-user:
 
 User
 ----
 
 A user in CrateDB Cloud is any individual account authorized to interact with
-some part of an :ref:`organization<glossary-org>`'s assets. Each user has a
+some part of an :ref:`organization's <gloss-org>` assets. Each user has a
 defined role within the organization (see our reference on :ref:`user roles
 <user-roles>`) and is associated with a specific email address.
 
 .. NOTE::
+
     Note that currently each CrateDB Cloud user corresponds to only one
     organization.
 
@@ -358,6 +359,6 @@ defined role within the organization (see our reference on :ref:`user roles
 .. _Microsoft documentation on Azure: https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-whatis
 .. _subscription plans: https://crate.io/docs/cloud/reference/en/latest/subscription-plans.html
 .. _this article on our blog: https://crate.io/a/connecting-azure-iot-hub-and-cratedb-cloud-for-the-ingestion-of-sensor-data/
-.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _tutorial for deploying a CrateDB Cloud cluster from scratch: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
+.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/index.html
 .. _user roles: https://crate.io/docs/cloud/reference/en/latest/user-roles.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,13 @@ CrateDB Cloud Reference
 
 `CrateDB Cloud`_ is a ready version of `CrateDB`_ as a service that runs in the
 cloud and is managed by the experts at `Crate.io`_. CrateDB Cloud supports
-real-time analytics and visualization specialized for the :ref:`Industrial Internet
-of Things (IIoT)<glossary-iiot>` at scale.
+real-time analytics and visualization specialized for the :ref:`Industrial
+Internet of Things (IIoT) <gloss-iiot>` at scale.
 
 .. SEEALSO::
 
     This is an open source documentation project. We host the source code and
     issue tracker on `GitHub`_.
-
 
 .. rubric:: Table of contents
 


### PR DESCRIPTION
Version 0.14 of crate-docs-theme includes a special CSS style for links that
reference glossary entries. It does this by checking the `href` attribute for
the `#gloss-` string. For this to work, all labels used for terms in the
glossary should be prefixed with `gloss-`.

The `gloss-` prefix was chosen for the CrateDB Reference glossary because we
make heavy use of cross-referencing (i.e., the main docs repeatedly hyperlink
phrases to the relevant glossary term) and using `gloss-` instead of
`glossary-` cuts down on hard wrapping requirements (and also makes typing them
all a little easier).

I grepped the Cloud Reference docs for cross-references to the glossary, but I
could not find any outside of the glossary itself and the top-level
`index.rst`. Do you link to any of the defined terms from elsewhere? If so,
those links will need to be updated.

As an aside, we have found that cross-referencing the main docs to link to the
glossary is providing a lot of value through increased navigability and
discoverability. Check it out and see what you think:
<https://crate.io/docs/crate/reference/en/master/appendices/glossary.html>

With this change in place, links to defined terms will be styled black with a
dotted underline. This styling has been chosen to reduce visual noise and
indicate to the reader that a link goes to the glossary as opposed to a
location in the main documentation.

You may need to run `make reset` before you can pick up the theme changes.

This change also fixes a few minor RST style issues.

---

forgot to mention in my commit: when you visit https://crate.io/docs/crate/reference/en/master/appendices/glossary.html, click through to some of the pages mentioned in the SEEALSO blocks and check the page for those links back to the glossary (black dotted underline)

the thing I want to draw your attention to is how these two things work in tandem:

- lots of SEEALSO blocks that provide a really cool way to signpost areas in the docs that relate to the current term. for example, check out the "regular expression" term. those pages I link to are pretty hard to find if all you're doing is clicking around the main docs looking for info about regular expressions. so in this way, the glossary entry serves one of those signposts with multiple arrows pointing in different directions. it serves to orient the user and aid in navigability

- in the main docs, cross-referencing lots of terms back to the glossary. this improves discoverability. because let's say you're on a page that mentions regular expressions in passing. you might be like "hmm, I am interested in that topic" so you click the link. boom. you're taken to a neat little section with a bunch of SEEALSO links that point you back to related places in the docs

it's a really powerful system and one I didn't even realize would come out of this work!!