### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @crate/tech-writing


### PR DESCRIPTION
The `@crate/tech-writing` team no longer exists.
