### PR TITLE
Modernize documentation infrastructure

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -45,9 +45,7 @@ You must install `fswatch`_ to use the ``dev`` target.
 Continuous integration and deployment
 -------------------------------------
 
-|build| |travis| |rtd|
-
-Travis CI is `configured`_ to run ``make check`` from the ``docs`` directory.
+CI is configured to run ``make check`` from the ``docs`` directory.
 Please do not merge pull requests until the tests pass.
 
 `Read the Docs`_ (RTD) automatically deploys the documentation whenever a
@@ -58,23 +56,7 @@ release version), please contact the `@crate/tech-writing`_ team.
 
 
 .. _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
-.. _configured: https://github.com/crate/cloud-reference/blob/master/.travis.yml
 .. _fswatch: https://github.com/emcrisostomo/fswatch
 .. _Read the Docs: http://readthedocs.org
 .. _ReStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org/
-
-
-.. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcloud-reference%2Fmaster%2Fdocs%2Fbuild.json
-    :alt: Build version
-    :target: https://github.com/crate/cloud-reference/blob/master/docs/build.json
-
-.. |travis| image:: https://img.shields.io/travis/crate/cloud-reference.svg?style=flat
-    :alt: Travis CI status
-    :scale: 100%
-    :target: https://travis-ci.org/crate/cloud-reference
-
-.. |rtd| image:: https://readthedocs.org/projects/crate-cloud-reference/badge/?version=latest
-    :alt: Read The Docs status
-    :scale: 100%
-    :target: https://crate-cloud-reference.readthedocs.io/en/latest/?badge=latest

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 CrateDB Cloud Reference
 =======================
 
+|ci| |rtd| |build|
+
+
 Reference documentation for `CrateDB Cloud`_.
 
 
@@ -29,3 +32,18 @@ Looking for more help?
 .. _developer docs: DEVELOP.rst
 .. _live docs: https://crate.io/docs/cloud/reference/en/latest/
 .. _support channels: https://crate.io/support/
+
+
+.. |ci| image:: https://github.com/crate/cloud-reference/actions/workflows/docs.yml/badge.svg
+    :alt: CI status
+    :scale: 100%
+    :target: https://github.com/crate/cloud-reference/actions/workflows/docs.yml
+
+.. |rtd| image:: https://readthedocs.org/projects/crate-cloud-reference/badge/?version=latest
+    :alt: Read The Docs status
+    :scale: 100%
+    :target: https://crate-cloud-reference.readthedocs.io/en/latest/?badge=latest
+
+.. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcloud-reference%2Fmaster%2Fdocs%2Fbuild.json
+    :alt: Build version
+    :target: https://github.com/crate/cloud-reference/blob/master/docs/build.json

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,8 +18,58 @@
 # pursuant to the terms of the relevant commercial agreement.
 
 
-# Do not edit anything below this line
-###############################################################################
+# =============================================================================
+# Crate Docs
+# =============================================================================
+
+# The Crate Docs project provides a common set of tools for producing the
+# Crate.io documentation. See <https://github.com/crate/crate-docs/> for more
+# information.
+
+# This file is taken from the demo Sphinx project available at
+# <https://github.com/crate/crate-docs/blob/main/docs>. This demo docs project
+# provides a reference implementation that should be copied for all Sphinx
+# projects at Crate.io.
+
+# The Crate Docs build system works by centralizing its core components in the
+# `crate-docs` repository. At build time, this Makefile creates a copy of the
+# this project under the `.crate-docs` directory. This Makefile is an interface
+# for those core components.
+
+
+# Upgraded instructions
+# -----------------------------------------------------------------------------
+
+# You must pin your Sphinx project to a specific version of the Crate Docs
+# project. You can do this by editing the `build.json` file. Change the JSON
+# `message` value to the desired release number. A list of releases is
+# available at <https://github.com/crate/crate-docs/releases>.
+
+# Although care has been taken to restrict changes to the core components, you
+# may occasionally need to update your project to match the reference
+# implementation. Check the release notes for any special instructions.
+
+
+# Project-specific customization
+# =============================================================================
+
+# If you want to customize the build system for your Sphinx project, add lines
+# to this section.
+
+
+# Build system integration
+# =============================================================================
+
+# This is a boilerplate section is required for integration with the Crate Docs
+# build system. All Sphinx projects using a the same Crate Docs version
+# should have exactly the same boilerplate.
+
+# IF YOU ARE EDITING THIS FILE IN A REAL SPHINX PROJECT, YOU SHOULD NOT MAKE
+# ANY CHANGES TO THIS SECTION.
+
+# If you want to make changes to the boilerplate, please make a pull request on
+# the demo Sphinx project in the Crate Docs repository available at
+# <https://github.com/crate/crate-docs/blob/main/docs>.
 
 .EXPORT_ALL_VARIABLES:
 
@@ -27,36 +77,69 @@ DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs.git
+LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
 CLONE_DIR     := .crate-docs
-SRC_DIR       := $(CLONE_DIR)/src
-SELF_SRC      := $(TOP_DIR)/src
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
-BUILD_VERSION = $(shell cat $(BUILD_JSON) | \
+BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
     python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
-$(error No version specified in $(BUILD_JSON))
+$(error No build version specified in `$(BUILD_JSON)`.)
+endif
+
+# This is a non-essential check so we timeout after only two seconds so as not
+# to frustrate the user when there are network issues
+LATEST_VERSION := $(shell curl -sI --connect-timeout 2 '$(LATEST_BUILD)' | \
+    grep -i 'Location:' | grep -Eoh '[^/]+$$')
+
+# Skip if no version could be determined (i.e., because of a network error)
+ifneq ($(LATEST_VERSION),)
+# Only issue a warning if there is a version mismatch
+ifneq ($(BUILD_VERSION),$(LATEST_VERSION))
+define version_warning
+You are using Crate Docs version $(BUILD_VERSION), however version \
+$(LATEST_VERSION) is available. You should consider upgrading. Follow the \
+instructions in `Makefile` and then run `make reset`.
+endef
+endif
 endif
 
 # Default rule
 .PHONY: help
 help: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
+
+.PHONY: version-warn
+version-warn:
+	@ # Because version numbers may vary in length, we must wrap the warning
+	@ # message at run time to be sure of correct output
+	@ if test -n '$(version_warning)'; then \
+	      printf '\033[33m'; \
+	      echo '$(version_warning)' | fold -w 79 -s; \
+	      printf '\033[00m\n'; \
+	  fi
 
 ifneq ($(wildcard $(SELF_MAKEFILE)),)
 # The project detects itself and fakes an install of its own core build rules
 # so that it can test itself
 $(CLONE_DIR):
-	mkdir -p $@
-	cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ mkdir -p $@
+	@ cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 else
 # All other projects install a versioned copy of the core build rules
 $(CLONE_DIR):
-	git clone --depth=1 -c advice.detachedHead=false \
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ git clone --depth=1 -c advice.detachedHead=false \
 	    --branch=$(BUILD_VERSION) $(BUILD_REPO) $(CLONE_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 endif
 
 # Don't pass through this target
@@ -66,8 +149,11 @@ Makefile:
 # By default, pass targets through to the core build rules
 .PHONY:
 %: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
 
 .PHONY: reset
 reset:
-	rm -rf $(CLONE_DIR)
+	@ printf '\033[1mResetting the build system...\033[00m\n'
+	@ rm -rf $(CLONE_DIR)
+	@ printf 'Removed: $(CLONE_DIR)\n'

--- a/docs/billing.rst
+++ b/docs/billing.rst
@@ -64,7 +64,9 @@ Invoicing
 
 Invoicing is handled variously depending on which deployment method you use.
 If you deploy your cluster directly via the CrateDB Cloud Console, you will be
-invoiced at the email address you provided on `signing up with CrateDB Cloud`_.
+invoiced at the email address you provided on :ref:`signing up with CrateDB
+Cloud <cloud-tutorials:sign-up>`.
+
 If you use one of the marketplace offers, the invoicing is handled by the
 marketplace provider in question and will be part of your general invoicing for
 services via that marketplace.
@@ -80,7 +82,8 @@ owners (Microsoft Azure and AWS).
 Payment processing
 ==================
 
-For clusters deployed in the `regular way`_, using our CrateDB Console cluster
+For clusters deployed in the :ref:`regular way
+<cloud-tutorials:cluster-deployment-stripe>`, using our CrateDB Console cluster
 deployment route, payment processing is handled by `Stripe`_. For clusters
 deployed through the `Microsoft Azure Marketplace`_ and the `AWS Marketplace`_,
 payment is handled by Stripe on behalf of the respective marketplaces.
@@ -88,6 +91,4 @@ payment is handled by Stripe on behalf of the respective marketplaces.
 
 .. _AWS Marketplace: https://aws.amazon.com/marketplace/pp/B089M4B1ND
 .. _Microsoft Azure Marketplace: https://portal.azure.com/#create/crate.cratedbcloud/preview
-.. _regular way: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/stripe.html
-.. _signing up with CrateDB Cloud:
-.. _Stripe: https://stripe.com/en-de
+.. _Stripe: https://stripe.com/

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.4.0"
+  "message": "2.0.0"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,4 +2,9 @@ from crate.theme.rtd.conf.cloud_reference import *
 
 linkcheck_ignore = [
     "https://eks1.eu-west-1.aws.cratedb.cloud",
+    "https://eastus2.azure.cratedb.cloud/",
+    "https://portal.azure.com/",
+    "https://azuremarketplace.microsoft.com/",
 ]
+
+linkcheck_timeout = 5

--- a/docs/subscription-plans.rst
+++ b/docs/subscription-plans.rst
@@ -82,10 +82,11 @@ below:
 Azure
 -----
 
-To sign a CrateDB Cloud Contract via Microsoft Azure, follow the `initial steps
-for signup`_ while selecting the CrateDB Cloud Contract as your subscription
-plan. This will automatically alert our Sales team, who will get in touch with
-you to configure the specifics of your contract according to your needs.
+To sign a CrateDB Cloud Contract via Microsoft Azure, follow the :ref:`initial
+steps for signup <cloud-tutorials:signup-azure-to-cluster-offer>` while
+selecting the CrateDB Cloud Contract as your subscription plan. This will
+automatically alert our Sales team, who will get in touch with you to configure
+the specifics of your contract according to your needs.
 
 
 AWS
@@ -207,5 +208,4 @@ For clarity, we add here a few notes of caution:
 .. _AWS offer page: https://aws.amazon.com/marketplace/pp/B089M4B1ND
 .. _Azure offer page: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/crate.cratedbcloud?tab=Overview
 .. _Contract page on the AWS Marketplace: https://aws.amazon.com/marketplace/pp/B08KHK34RK
-.. _initial steps  for signup: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/deploy-to-cluster-azure/signup-azure.html#using-the-cratedb-cloud-offer-on-azure-marketplace
 .. _Sales team: sales@crate.io

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -28,8 +28,8 @@ CrateDB Cloud user roles
 ========================
 
 This section describes the roles that can be set for users within CrateDB
-Cloud. For information on how to do so, see our documentation on `adding
-users`_.
+Cloud. For information on how to do so, see our documentation on ref:`adding
+users <crate-reference:add-users>`.
 
 
 .. _org-roles:
@@ -112,7 +112,8 @@ Regular database user
 
 Next to the ``crate`` user there is the regular database user, created as part
 of the CrateDB Cloud cluster deployment wizard when deploying a cluster through
-`AWS`_ or `Azure`_.
+:ref:`AWS <cloud-tutorials:configure-aws-to-cluster>` or
+:ref:`Azure <cloud-tutorials:configure-azure-to-cluster>`.
 
 Because the regular database user has `AL privileges`_, there are certain
 operations that they cannot perform. As of CrateDB 4.2.1, the list of such
@@ -127,12 +128,8 @@ operations is as follows:
 | ``SET LICENSE``
 | ``SET TRANSACTION``
 
-More information on CrateDB user privileges can be found in the `CrateDB
-documentation on privileges`_.
+More information on CrateDB user privileges can be found in the :ref:`CrateDB
+documentation on privileges <crate-reference:administration-privileges>`.
 
 
-.. _adding users: https://crate.io/docs/cloud/howtos/en/latest/add-users.html
-.. _AWS: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/deploy-to-cluster-aws/configure-aws.html#wizard-step-2
-.. _Azure: https://crate.io/docs/cloud/tutorials/en/latest/cluster-deployment/deploy-to-cluster-azure/configure-azure.html#wizard-step-2
 .. _AL privileges: https://crate.io/docs/crate/reference/en/latest/admin/privileges.html#al
-.. _CrateDB documentation on privileges: https://crate.io/docs/crate/reference/en/latest/admin/privileges.html


### PR DESCRIPTION
Hi @matthijskrul,

this patch modernizes the documentation infrastructure.

- Upgrade to the most recent "crate-docs" version.
- Use some intersphinx links instead of absolute URIs.

With kind regards,
Andreas.
