### PR TITLE
Make cluster deletion easier to find in Console overview ToC

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -109,12 +109,11 @@ Consumer
 --------
 
 A consumer in the sense used for CrateDB Cloud architecture and documentation
-is an entity that reads event data from an :ref:`IoT <gloss-iot>` hub. It is
-possible to use a consumer, such as Azure IoT Hub, with CrateDB Cloud: you can
-store the data processed by the consumer on the Cloud :ref:`cluster
-<gloss-cluster>`. For a tutorial on how to do this, see `this article on our
-blog`_. Operations on consumers are registered in the :ref:`Audit Log
-<gloss-audit-log>`.
+is an entity that reads event data from an IoT hub. It is possible to use a
+consumer, such as Azure IoT Hub, with CrateDB Cloud: you can store the data
+processed by the consumer on the Cloud :ref:`cluster <gloss-cluster>`. For a
+tutorial on how to do this, see `this article on our blog`_. Operations on
+consumers are registered in the :ref:`Audit Log <gloss-audit-log>`.
 
 .. SEEALSO::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,10 +4,12 @@
 CrateDB Cloud Reference
 =======================
 
-`CrateDB Cloud`_ is a ready version of `CrateDB`_ as a service that runs in the
-cloud and is managed by the experts at `Crate.io`_. CrateDB Cloud supports
-real-time analytics and visualization specialized for the :ref:`Industrial
-Internet of Things (IIoT) <gloss-iiot>` at scale.
+`CrateDB Cloud`_ is the fully-managed cloud database as a service by
+`CrateDB`_. With CrateDB Cloud you can deploy, monitor, back up, and scale your
+clusters in the cloud – without needing to worry about database management.
+
+CrateDB is a distributed, open-source database that combines the performance of
+NoSQL with the power and simplicity of standard SQL.
 
 .. SEEALSO::
 
@@ -27,7 +29,6 @@ Internet of Things (IIoT) <gloss-iiot>` at scale.
     glossary
 
 
-.. _Crate.io: https://crate.io/
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _GitHub: https://github.com/crate/cloud-reference/

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -439,8 +439,15 @@ the *Edit scale unit* button to adjust the scaling to the desired level.
     scale pricing shown here, but do not worry! This does not mean that your
     promotion or discount is not functioning.
 
-You can also delete your cluster here by clicking the *Delete cluster* button
-at the top right. It will prompt you for confirmation.
+
+.. _overview-cluster-settings-delete:
+
+Delete cluster
+''''''''''''''
+
+You can also delete your cluster in either tab of the Cluster Preferences by
+clicking the *Delete cluster* button at the top right. It will prompt you for
+confirmation.
 
 .. WARNING::
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Make cluster deletion its own subheader level item so it's easier to find as an operation in the reference
- Update marketing text in reference to conform to that in the tutorials index
- Minor fixes in glossary after removal of IoT and IIoT elements

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
