### PR TITLE
Clarify authentication for `crate` user.

### DIFF
--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -103,6 +103,7 @@ In CrateDB, when you create a cluster node (through whatever method), a
 ``crate`` user is automatically generated. ``crate`` is a superuser and can
 perform all possible operations. It is not possible to create additional
 superusers.
+Authentication for ``crate`` is restricted to ``localhost``.
 
 
 .. _db-user:


### PR DESCRIPTION
We want to be explicity about the restrictions for the authentication of the user `crate`. It does **not** allow authentication from the network. HBA configuration allows only access from `localhost`.
